### PR TITLE
Adds an API Key for Model Download; Adds Model Metadata for Sorting

### DIFF
--- a/src/cocktail/core/database/api.py
+++ b/src/cocktail/core/database/api.py
@@ -18,7 +18,7 @@ import importlib.resources
 from PySide6 import QtSql
 from cocktail.core.database import data_classes
 
-CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
 
 logger = logging.getLogger(__name__)
 

--- a/src/cocktail/core/database/data_classes.py
+++ b/src/cocktail/core/database/data_classes.py
@@ -92,6 +92,14 @@ class Model(typing.NamedTuple):
     image_blur_hash: str
     description: str
     updated_at: int
+    download_cnt: int
+    favorite_cnt: int
+    thumbs_up_cnt: int
+    thumbs_down_cnt: int
+    comment_cnt: int
+    rating_cnt: int
+    rating_score: float
+    tipped_amt_cnt: int
 
     @classmethod
     def from_json(cls, data: dict):
@@ -122,6 +130,14 @@ class Model(typing.NamedTuple):
             image_blur_hash=image_data.get("hash", "") or "",
             description=data["description"] or "",
             updated_at=timestamp,
+            download_cnt=data["stats"]["downloadCount"],
+            favorite_cnt=data["stats"]["favoriteCount"],
+            thumbs_up_cnt=data["stats"]["thumbsUpCount"],
+            thumbs_down_cnt=data["stats"]["thumbsDownCount"],
+            comment_cnt=data["stats"]["commentCount"],
+            rating_cnt=data["stats"]["ratingCount"],
+            rating_score=data["stats"]["rating"],
+            tipped_amt_cnt=data["stats"]["tippedAmountCount"]
         )
 
     @classmethod
@@ -138,6 +154,14 @@ class Model(typing.NamedTuple):
             image_blur_hash=record.value("image_blur_hash"),
             description=record.value("description"),
             updated_at=record.value("updated_at"),
+            download_cnt=record.value("download_cnt"),
+            favorite_cnt=record.value("favorite_cnt"),
+            thumbs_up_cnt=record.value("thumbs_up_cnt"),
+            thumbs_down_cnt=record.value("thumbs_down_cnt"),
+            comment_cnt=record.value("comment_cnt"),
+            rating_cnt=record.value("rating_cnt"),
+            rating_score=record.value("rating_score"),
+            tipped_amt_cnt=record.value("tipped_amt_cnt")
         )
 
 
@@ -249,6 +273,11 @@ class ModelVersion(typing.NamedTuple):
     description: str
     trained_words: typing.List[str]
     base_model: str
+    download_cnt: int
+    rating_cnt: int
+    rating_score: float
+    thumbs_up_cnt: int
+    thumbs_down_cnt: int
 
     @classmethod
     def from_json(cls, model_id: int, data: dict):
@@ -259,6 +288,11 @@ class ModelVersion(typing.NamedTuple):
             description=data["description"] or "",
             trained_words=data["trainedWords"],
             base_model=data.get("baseModel", "Other"),
+            download_cnt=data["stats"]["downloadCount"],
+            rating_cnt=data["stats"]["ratingCount"],
+            rating_score=data["stats"]["rating"],
+            thumbs_up_cnt=data["stats"]["thumbsUpCount"],
+            thumbs_down_cnt=data["stats"]["thumbsDownCount"],
         )
 
     @classmethod
@@ -270,6 +304,11 @@ class ModelVersion(typing.NamedTuple):
             description=record.value("description"),
             trained_words=json.loads(record.value("trained_words")),
             base_model=record.value("base_model"),
+            download_cnt=record.value("download_cnt"),
+            rating_cnt=record.value("rating_cnt"),
+            rating_score=record.value("rating_score"),
+            thumbs_up_cnt=record.value("thumbs_up_cnt"),
+            thumbs_down_cnt=record.value("thumbs_down_cnt"),
         )
 
 

--- a/src/cocktail/core/database/schema.sql
+++ b/src/cocktail/core/database/schema.sql
@@ -1,6 +1,6 @@
 pragma journal_mode = WAL;
 pragma synchronous = normal;
-pragma user_version = 2;
+pragma user_version = 3;
 
 CREATE TABLE IF NOT EXISTS model (
     id INTEGER PRIMARY KEY,
@@ -13,8 +13,17 @@ CREATE TABLE IF NOT EXISTS model (
     image TEXT NOT NULL,
     image_blur_hash TEXT NOT NULL,
     description TEXT NOT NULL,
-    updated_at INTEGER NOT NULL
+    updated_at INTEGER NOT NULL,
+    download_cnt INTEGER NOT NULL,
+    favorite_cnt INTEGER NOT NULL,
+    thumbs_up_cnt INTEGER NOT NULL,
+    thumbs_down_cnt INTEGER NOT NULL,
+    comment_cnt INTEGER NOT NULL,
+    rating_cnt INTEGER NOT NULL,
+    rating_score REAL NOT NULL,
+    tipped_amt_cnt INTEGER NOT NULL
 );
+
 
 CREATE TABLE IF NOT EXISTS model_version (
     id INTEGER PRIMARY KEY,
@@ -23,6 +32,11 @@ CREATE TABLE IF NOT EXISTS model_version (
     description TEXT NOT NULL,
     trained_words TEXT NOT NULL,
     base_model TEXT NOT NULL,
+    download_cnt INTEGER NOT NULL,
+    rating_cnt INTEGER NOT NULL,
+    rating_score REAL NOT NULL,
+    thumbs_up_cnt INTEGER NOT NULL,
+    thumbs_down_cnt INTEGER NOT NULL,
     FOREIGN KEY (model_id) REFERENCES model (id)
 );
 
@@ -55,10 +69,15 @@ CREATE TABLE IF NOT EXISTS model_image (
     FOREIGN KEY (model_version_id) REFERENCES model_version (id)
 );
 
-
 CREATE TABLE IF NOT EXISTS metadata (
     id INTEGER PRIMARY KEY,
     key TEXT NOT NULL,
     value TEXT NOT NULL,
     UNIQUE (key)
+);
+
+CREATE TABLE IF NOT EXISTS download_history (
+    id INTEGER PRIMARY KEY,
+    download_count INTEGER NOT NULL,
+    FOREIGN KEY (model_version_id) REFERENCES model_version (id)
 );

--- a/src/cocktail/ui/database/controller.py
+++ b/src/cocktail/ui/database/controller.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     db = db_api.get_connection()
 
     controller = DatabaseController(db)
-    controller.updateModelData(period=data_classes.Period.Day)
+    controller.updateModelData(period=data_classes.Period.AllTime)
     controller.view.show()
 
     app.exec()

--- a/src/cocktail/ui/download/controller.py
+++ b/src/cocktail/ui/download/controller.py
@@ -149,7 +149,11 @@ class ModelDownloadController(QtCore.QObject):
         with open(json_path, "w") as f:
             json.dump(metadata, f, indent=4)
 
-        reply = self._download(model_file.url, final_path)
+        api_key = ""
+        if (k := os.environ.get('CIVITAI_API_KEY', None)) is not None:
+            api_key = f"?token={k}"
+
+        reply = self._download(model_file.url + api_key, final_path)
 
         widget = self.view.addDownload(model_file.name, reply)
         widget.requestOpenDirectory.connect(

--- a/src/cocktail/ui/search/controller.py
+++ b/src/cocktail/ui/search/controller.py
@@ -49,6 +49,9 @@ class SearchController(QtCore.QObject):
         self.sort_order_model.appendRow(QtGui.QStandardItem("Updated"))
         self.sort_order_model.appendRow(QtGui.QStandardItem("Name"))
         self.sort_order_model.appendRow(QtGui.QStandardItem("Id"))
+        self.sort_order_model.appendRow(QtGui.QStandardItem("Highest Rating"))
+        self.sort_order_model.appendRow(QtGui.QStandardItem("Most Downloads"))
+        self.sort_order_model.appendRow(QtGui.QStandardItem("Most ThumbsUps"))
         if value:
             self.view.setSortOrder(value)
 
@@ -167,6 +170,12 @@ class SearchController(QtCore.QObject):
             order_by = "id DESC"
         elif sort_order == "Name":
             order_by = "name ASC"
+        elif sort_order == "Highest Rating":
+            order_by = "rating_score DESC"
+        elif sort_order == "Most Downloads":
+            order_by = "download_cnt DESC"
+        elif sort_order == "Most ThumbsUps":
+            order_by = "thumbs_up_cnt DESC"
         else:
             order_by = "updated_at DESC"
 


### PR DESCRIPTION
This PR adds two features that may be interesting: First, an API key can optionally be taken from an environment variable to download models that require login. Second, the database includes metadata for the models and its version. It is used to, e.g., sort by most downloads. Currently, sorting is only added at the model level. This requires an increase in the schema user version. To support future filtering by (not) downloaded models, a currently unused table has already been added to keep track of the download history.

Note: Requires updating the provided release database. If a download history is used, it must be reset for the release (or re-initialized from disk paths).